### PR TITLE
Dynamic join buttons via database

### DIFF
--- a/mybot/database/mongo.py
+++ b/mybot/database/mongo.py
@@ -3,3 +3,10 @@ from mybot import config
 
 mongo_client = AsyncIOMotorClient(config.MONGO_URI)
 db = mongo_client["refer_bot"]
+
+# Collections used across the bot
+users_col = db["users"]
+referrals_col = db["referrals"]
+
+# New settings collection for dynamic configuration
+settings_col = db["settings"]


### PR DESCRIPTION
## Summary
- manage button links in MongoDB `settings` collection
- add owner commands to update or list join buttons
- build join buttons dynamically in `/start`
- verify joins using stored button links

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688b4c23b50c83298e3182708f5e18cc