### PR TITLE
Fix verify join button logic

### DIFF
--- a/mybot/plugins/start.py
+++ b/mybot/plugins/start.py
@@ -23,7 +23,12 @@ def get_start_keyboard(user_id: int, join_buttons: list) -> InlineKeyboardMarkup
             InlineKeyboardButton("💎 Referral", callback_data="referral"),
             InlineKeyboardButton("💰 Withdraw", callback_data="withdraw")
         ],
-        [InlineKeyboardButton("✅ Verify Join", callback_data="verify")],
+    ]
+
+    if join_buttons:
+        buttons.append([InlineKeyboardButton("✅ Verify Join", callback_data="verify")])
+
+    buttons += [
         [
             InlineKeyboardButton("📊 My Points", callback_data="mypoints"),
             InlineKeyboardButton("🏆 Top Users", callback_data="top")

--- a/mybot/plugins/verify.py
+++ b/mybot/plugins/verify.py
@@ -1,5 +1,5 @@
 from pyrogram import Client, filters
-from pyrogram.enums import ParseMode
+from pyrogram.enums import ParseMode, ChatMemberStatus
 from mybot.database.mongo import settings_col
 
 
@@ -33,7 +33,7 @@ async def verify_cb(client, callback_query):
             continue
         try:
             member = await client.get_chat_member(username, user_id)
-            if member.status in ("kicked", "left"):
+            if member.status in {ChatMemberStatus.BANNED, ChatMemberStatus.LEFT}:
                 missing.append(username)
         except Exception:
             missing.append(username)


### PR DESCRIPTION
## Summary
- show "Verify Join" button only when channels exist
- correctly detect banned/left users using `ChatMemberStatus`

## Testing
- `pytest -q`
- `python3 -m compileall -q mybot`

------
https://chatgpt.com/codex/tasks/task_b_688b4da2673c8329adf10b09848a709c