### PR TITLE
Fix bot launch path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN pip install --no-cache-dir -r mybot/requirements.txt
 # Copy the rest of the project
 COPY mybot ./mybot
 
-# Switch to project directory
-WORKDIR /app/mybot
+# Ensure /app is on PYTHONPATH and run as a package
+ENV PYTHONPATH=/app
 
-# Start the bot
-CMD ["python3", "main.py"]
+# Start the bot using module notation so imports work
+CMD ["python3", "-m", "mybot.main"]

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cd mybot
 pip install -r requirements.txt
 cp .env.example .env
 # Fill .env with your credentials
-python main.py
+python -m mybot.main
 
 Render / Railway Deployment
 	•	Add environment variables in the dashboard.

--- a/mybot/render.yaml
+++ b/mybot/render.yaml
@@ -20,7 +20,7 @@ services:
     env: python
     plan: free
     buildCommand: pip install -r requirements.txt
-    startCommand: python main.py
+    startCommand: python -m mybot.main
     envVars:
       - key: API_ID
         value: YOUR_API_ID

--- a/mybot/start.sh
+++ b/mybot/start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-# Ensure script runs from its directory
-cd "$(dirname "$0")"
-python3 main.py
+# Ensure script runs from repository root
+cd "$(dirname "$0")"/..
+
+# Launch the bot using module notation so package imports resolve
+python3 -m mybot.main


### PR DESCRIPTION
## Summary
- ensure the `mybot` package can be imported
- adjust the local `start.sh` script to run from repo root
- update Render config and README instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688b514b5cf083299b88cb616addb68b