### PR TITLE
Fix Motor dependency mismatch

### DIFF
--- a/mybot/requirements.txt
+++ b/mybot/requirements.txt
@@ -3,7 +3,7 @@ pyrogram==2.0.106
 tgcrypto
 
 # MongoDB async driver
-motor==3.1.1
+motor==3.7.1
 
 # Environment variable loader
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- upgrade Motor to v3.7.1 for PyMongo 4.x compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r mybot/requirements.txt`
- `python -m mybot.main --help` *(fails: The API key is required for new authorizations)*

------
https://chatgpt.com/codex/tasks/task_b_688b52cef700832997e29071a4dbc1ff