### PR TITLE
Fix plugin loading and db init

### DIFF
--- a/mybot/database/__init__.py
+++ b/mybot/database/__init__.py
@@ -1,5 +1,17 @@
-from .mongo import db
+"""Database utilities for the bot."""
 
-async def init_db():
-    # You can create indexes or ensure collections here if needed
-    pass
+import logging
+
+from .mongo import db, mongo_client
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def init_db() -> None:
+    """Verify MongoDB connectivity and prepare collections."""
+    try:
+        await mongo_client.admin.command("ping")
+    except Exception as exc:
+        LOGGER.error("Failed to connect to MongoDB: %s", exc)
+    else:
+        LOGGER.info("MongoDB connection established")

--- a/mybot/main.py
+++ b/mybot/main.py
@@ -73,11 +73,10 @@ async def main():
     await init_db()
     LOGGER.info("✅ Database ready")
 
-    # Load plugins
-    load_plugins()
-
     LOGGER.info("🚀 Starting Refer & Earn Bot in polling mode...")
     async with app:
+        # Load plugins after the client starts so decorators bind correctly
+        load_plugins()
         LOGGER.info("✅ Bot is ready to receive updates.")
         await idle()
     LOGGER.info("Bot stopped cleanly.")

--- a/mybot/plugins/__init__.py
+++ b/mybot/plugins/__init__.py
@@ -1,59 +1,7 @@
-"""Plugin package loader for the Refer & Earn Bot.
+"""Plugin package for Refer & Earn Bot.
 
-This module dynamically imports all .py files inside the plugins directory
-and calls their `register(app)` function if present.
+This file intentionally remains empty. All plugin modules are imported
+ dynamically from :mod:`mybot.plugins` at runtime by the loader in
+ ``main.py``.
 """
 
-import importlib
-import logging
-import traceback
-from pathlib import Path
-from typing import Any
-
-LOGGER = logging.getLogger(__name__)
-LOGGER.info("📦 Plugins package initialized")
-
-
-def register_all(app: Any) -> int:
-    """
-    Import all plugin modules and register their handlers with the given app.
-    
-    Returns:
-        int: Number of plugins successfully registered.
-    """
-    loaded = 0
-    plugin_dir = Path(__file__).parent
-
-    for file in sorted(plugin_dir.glob("*.py")):
-        if file.name == "__init__.py":
-            continue
-
-        module_name = f"{__name__}.{file.stem}"
-        try:
-            LOGGER.info("🔄 Importing plugin: %s", file.stem)
-            module = importlib.import_module(module_name)
-        except Exception:
-            LOGGER.error(
-                "❌ Failed to import plugin %s\n%s",
-                file.stem,
-                traceback.format_exc()
-            )
-            continue
-
-        # If the plugin defines a register() function, call it
-        if hasattr(module, "register"):
-            try:
-                module.register(app)
-                loaded += 1
-                LOGGER.info("✅ Plugin loaded: %s", file.stem)
-            except Exception:
-                LOGGER.error(
-                    "❌ Error registering plugin %s\n%s",
-                    file.stem,
-                    traceback.format_exc()
-                )
-        else:
-            LOGGER.warning("⚠️ Plugin %s has no register() function", file.stem)
-
-    LOGGER.info("📦 Plugin loading complete: %d module(s) loaded", loaded)
-    return loaded


### PR DESCRIPTION
## Summary
- remove register_all loader and keep plugins/__init__ empty
- move plugin loading to main so decorators register after start
- check MongoDB connectivity and log errors
- keep ping command for health check

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b566d0cbc8329b89e0d4e0a256ce6