### PR TITLE
Fix plugin loading order

### DIFF
--- a/mybot/main.py
+++ b/mybot/main.py
@@ -74,9 +74,12 @@ async def main():
     LOGGER.info("✅ Database ready")
 
     LOGGER.info("🚀 Starting Refer & Earn Bot in polling mode...")
+
+    # Load plugins before the client starts so decorators bind correctly
+    plugin_count = load_plugins()
+    LOGGER.info("🔌 Loaded %s plugins", plugin_count)
+
     async with app:
-        # Load plugins after the client starts so decorators bind correctly
-        load_plugins()
         LOGGER.info("✅ Bot is ready to receive updates.")
         await idle()
     LOGGER.info("Bot stopped cleanly.")

--- a/mybot/plugins/test.py
+++ b/mybot/plugins/test.py
@@ -1,0 +1,5 @@
+from pyrogram import Client, filters
+
+@Client.on_message(filters.command("ping"))
+async def ping_test(_, message):
+    await message.reply_text("Pong! (test plugin)")


### PR DESCRIPTION
## Summary
- load plugins before starting the `Client`
- log plugin count once loaded
- add a simple test plugin

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688b59bf965c83299929667b673d5c3b