### PR TITLE
Improve bot start logic and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ BOT_TOKEN=your_bot_token
 OWNER_ID=123456789
 LOG_GROUP=-1001234567890
 MONGO_URI=mongodb+srv://user:pass@cluster.mongodb.net/dbname
+LOG_LEVEL=INFO
+---
+
+`LOG_LEVEL` controls the verbosity of log output. Use `DEBUG` while
+troubleshooting, otherwise keep the default `INFO` value.
 
 ---
 

--- a/mybot/config.py
+++ b/mybot/config.py
@@ -18,5 +18,9 @@ MONGO_URI = os.getenv("MONGO_URI")
 # Optional log group ID (for new user logs)
 LOG_GROUP = os.getenv("LOG_GROUP")  # e.g., -1001234567890
 
+# Logging level. Defaults to INFO if not set.
+# Example values: DEBUG, INFO, WARNING, ERROR
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
 # Referral/withdrawal settings
 MIN_WITHDRAW = 15

--- a/mybot/main.py
+++ b/mybot/main.py
@@ -16,7 +16,7 @@ LOG_DIR = Path("logs")
 LOG_DIR.mkdir(exist_ok=True)
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=getattr(logging, config.LOG_LEVEL, logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[
         logging.StreamHandler(sys.stdout),
@@ -63,6 +63,8 @@ async def main():
     app.load_plugins()
 
     async with app:
+        # Ensure no leftover webhook is set
+        await app.delete_webhook(drop_pending_updates=True)
         LOGGER.info("✅ Bot is ready to receive updates.")
         await idle()
     LOGGER.info("Bot stopped cleanly.")


### PR DESCRIPTION
## Summary
- add configurable `LOG_LEVEL` in `config.py`
- set logging level dynamically in `main.py`
- remove any leftover webhook on startup
- document `LOG_LEVEL` in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688d00b0572083298cda8fa92d45700c