### PR TITLE
Fix webhook deletion via Bot API

### DIFF
--- a/mybot/main.py
+++ b/mybot/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pyrogram import Client, filters, idle
 from pyrogram.errors import FloodWait
+import httpx
 from mybot import config
 from mybot.database import init_db
 
@@ -68,6 +69,17 @@ async def start_client_with_retry():
             await asyncio.sleep(wait_time)
 
 
+async def delete_webhook(drop_pending_updates: bool = True) -> None:
+    """Delete existing webhook via Bot API."""
+    url = f"https://api.telegram.org/bot{config.BOT_TOKEN}/deleteWebhook"
+    params = {"drop_pending_updates": str(drop_pending_updates).lower()}
+    async with httpx.AsyncClient() as client:
+        try:
+            await client.post(url, params=params)
+        except Exception as exc:
+            LOGGER.warning("Failed to delete webhook: %s", exc)
+
+
 async def main():
     # Initialize DB
     LOGGER.info("📚 Initializing database...")
@@ -82,7 +94,7 @@ async def main():
     await start_client_with_retry()
     try:
         # Ensure no leftover webhook is set
-        await app.delete_webhook(drop_pending_updates=True)
+        await delete_webhook(drop_pending_updates=True)
         LOGGER.info("✅ Bot is ready to receive updates.")
         await idle()
     finally:

--- a/mybot/requirements.txt
+++ b/mybot/requirements.txt
@@ -10,3 +10,4 @@ python-dotenv==1.0.1
 
 # For deployment on Render/Heroku
 uvloop; sys_platform != "win32"
+httpx


### PR DESCRIPTION
## Summary
- add httpx dependency for HTTP requests
- implement custom `delete_webhook` using Bot API
- call the new helper from `main.py` during startup

## Testing
- `python -m py_compile mybot/main.py`
- `python -m pip install -r mybot/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_688d09802df883298ab16aa3f31e0861