### PR TITLE
Fix verbose debug logging

### DIFF
--- a/mybot/config.py
+++ b/mybot/config.py
@@ -20,7 +20,7 @@ LOG_GROUP = os.getenv("LOG_GROUP")  # e.g., -1001234567890
 
 # Logging level. Defaults to INFO if not set.
 # Example values: DEBUG, INFO, WARNING, ERROR
-LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG").upper()
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 
 # Referral/withdrawal settings
 MIN_WITHDRAW = 15


### PR DESCRIPTION
## Summary
- reduce default logging level to INFO so PyMongo and Pyrogram debug logs don't flood output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688d0d3d21548329882b2ae382ef29ae