### PR TITLE
Improve error handling and plugin loading

### DIFF
--- a/mybot/main.py
+++ b/mybot/main.py
@@ -2,11 +2,13 @@
 
 import logging
 import sys
+from importlib import import_module
 from pathlib import Path
-from pyrogram import Client, idle
+
+from pyrogram import Client
+
 from mybot import config
 from mybot.database import init_db
-import asyncio
 
 # -------------------------------------------------------------
 # Logging setup
@@ -32,20 +34,36 @@ app = Client(
     api_id=config.API_ID,
     api_hash=config.API_HASH,
     bot_token=config.BOT_TOKEN,
-    plugins=dict(root="mybot/plugins"),
 )
+
+
+def load_plugins() -> None:
+    """Dynamically import all plugin modules and log them."""
+    plugins_path = Path(__file__).parent / "plugins"
+    for file in plugins_path.glob("*.py"):
+        if file.name.startswith("__"):
+            continue
+        module_name = f"mybot.plugins.{file.stem}"
+        try:
+            import_module(module_name)
+            LOGGER.info("Plugin loaded: %s", module_name)
+        except Exception as exc:  # pragma: no cover - import errors
+            LOGGER.exception("Failed to load plugin %s: %s", module_name, exc)
 
 # -------------------------------------------------------------
 # Entrypoint
 # -------------------------------------------------------------
-async def main():
-    LOGGER.info("📚 Initializing database...")
+async def start_bot() -> None:
+    LOGGER.info("\ud83d\udcdc Initializing database...")
     await init_db()
 
-    LOGGER.info("🚀 Starting Refer & Earn Bot in polling mode...")
-    await app.start()
-    await idle()
-    await app.stop()
+    LOGGER.info("\ud83d\udd27 Loading plugins...")
+    load_plugins()
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        app.run(start_bot())
+    except Exception as exc:  # pragma: no cover - runtime errors
+        LOGGER.exception("Bot stopped due to error: %s", exc)
+

--- a/mybot/plugins/admin.py
+++ b/mybot/plugins/admin.py
@@ -1,14 +1,21 @@
 from pyrogram import Client, filters
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from datetime import datetime
+import logging
+
 from mybot.database.mongo import users_col
 from mybot import config
 from mybot.button import SUPPORT_URL
-from datetime import datetime
+from mybot.utils.decorators import log_errors
+
+LOGGER = logging.getLogger(__name__)
 
 
 # Admin Panel callback button
 @Client.on_callback_query(filters.regex("^admin$") & filters.user(config.OWNER_ID))
+@log_errors
 async def admin_panel(client, callback_query):
+    LOGGER.info("Admin panel opened by %s", callback_query.from_user.id)
     text = (
         "🛠 <b>Admin Panel</b>\n\n"
         "Use the following commands:\n\n"
@@ -25,7 +32,9 @@ async def admin_panel(client, callback_query):
 
 # Show user points
 @Client.on_message(filters.command("points") & filters.user(config.OWNER_ID))
+@log_errors
 async def points_cmd(_, message):
+    LOGGER.info("/points used by %s", message.from_user.id)
     if len(message.command) < 2:
         return await message.reply_text(
             "⚠️ <b>Usage:</b> <code>/points &lt;user_id&gt;</code>", parse_mode="html"
@@ -36,7 +45,11 @@ async def points_cmd(_, message):
     except ValueError:
         return await message.reply_text("❌ Invalid user ID format.", parse_mode="html")
 
-    user = await users_col.find_one({"_id": uid})
+    try:
+        user = await users_col.find_one({"_id": uid})
+    except Exception as e:
+        LOGGER.exception("DB error in points_cmd: %s", e)
+        user = None
     if not user:
         return await message.reply_text(
             f"❌ No data found for user <code>{uid}</code>", parse_mode="html"
@@ -51,7 +64,9 @@ async def points_cmd(_, message):
 
 # Approve withdrawal
 @Client.on_message(filters.command("approve") & filters.user(config.OWNER_ID))
+@log_errors
 async def approve_cmd(client, message):
+    LOGGER.info("/approve used by %s", message.from_user.id)
     if len(message.command) < 2:
         return await message.reply_text(
             "⚠️ <b>Usage:</b> <code>/approve &lt;user_id&gt;</code>", parse_mode="html"
@@ -62,7 +77,11 @@ async def approve_cmd(client, message):
     except ValueError:
         return await message.reply_text("❌ Invalid user ID format.", parse_mode="html")
 
-    user = await users_col.find_one({"_id": uid})
+    try:
+        user = await users_col.find_one({"_id": uid})
+    except Exception as e:
+        LOGGER.exception("DB error in approve_cmd: %s", e)
+        user = None
     if not user or not user.get("pending_withdrawal"):
         return await message.reply_text(
             "❌ No pending withdrawal request for this user.", parse_mode="html"
@@ -76,10 +95,13 @@ async def approve_cmd(client, message):
             "⚠️ Insufficient points in user's account.", parse_mode="html"
         )
 
-    await users_col.update_one(
-        {"_id": uid},
-        {"$inc": {"points": -amount}, "$unset": {"pending_withdrawal": ""}},
-    )
+    try:
+        await users_col.update_one(
+            {"_id": uid},
+            {"$inc": {"points": -amount}, "$unset": {"pending_withdrawal": ""}},
+        )
+    except Exception as e:
+        LOGGER.exception("DB update failed in approve_cmd: %s", e)
 
     await message.reply_text(
         f"✅ Approved withdrawal of <b>{amount}</b> points for user <code>{uid}</code>",
@@ -109,7 +131,9 @@ async def approve_cmd(client, message):
 
 # Reject withdrawal
 @Client.on_message(filters.command("reject") & filters.user(config.OWNER_ID))
+@log_errors
 async def reject_cmd(_, message):
+    LOGGER.info("/reject used by %s", message.from_user.id)
     if len(message.command) < 2:
         return await message.reply_text(
             "⚠️ <b>Usage:</b> <code>/reject &lt;user_id&gt;</code>", parse_mode="html"
@@ -120,14 +144,22 @@ async def reject_cmd(_, message):
     except ValueError:
         return await message.reply_text("❌ Invalid user ID format.", parse_mode="html")
 
-    user = await users_col.find_one({"_id": uid})
+    try:
+        user = await users_col.find_one({"_id": uid})
+    except Exception as e:
+        LOGGER.exception("DB error in reject_cmd: %s", e)
+        user = None
     if not user or not user.get("pending_withdrawal"):
         return await message.reply_text(
             "❌ No pending withdrawal request for this user.", parse_mode="html"
         )
 
-    await users_col.update_one({"_id": uid}, {"$unset": {"pending_withdrawal": ""}})
+    try:
+        await users_col.update_one({"_id": uid}, {"$unset": {"pending_withdrawal": ""}})
+    except Exception as e:
+        LOGGER.exception("DB update failed in reject_cmd: %s", e)
     await message.reply_text(
         f"❌ Rejected withdrawal request from user <code>{uid}</code>",
         parse_mode="html",
     )
+

--- a/mybot/plugins/start.py
+++ b/mybot/plugins/start.py
@@ -1,8 +1,13 @@
 from pyrogram import Client, filters
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+import logging
+
 from mybot import config
 from mybot.button import CHANNEL_LINKS, SUPPORT_URL
 from mybot.database.mongo import users_col, referrals_col
+from mybot.utils.decorators import log_errors
+
+LOGGER = logging.getLogger(__name__)
 
 # Banner image shown on /start
 BANNER_URL = "https://via.placeholder.com/600x300.png?text=Refer+%26+Earn"
@@ -52,7 +57,9 @@ def get_start_keyboard(user_id: int) -> InlineKeyboardMarkup:
 
 
 @Client.on_message(filters.command("start"))
+@log_errors
 async def start_cmd(client, message):
+    LOGGER.info("/start invoked by %s", message.from_user.id)
     user_id = message.from_user.id
     parts = message.text.split(maxsplit=1)
     referrer = None
@@ -86,7 +93,7 @@ async def start_cmd(client, message):
 
     except Exception as e:
         # Log database errors so they don't block responses
-        print(f"DB error in /start: {e}")
+        LOGGER.exception("DB error in /start: %s", e)
 
     # Always respond even if DB fails
     await message.reply_photo(

--- a/mybot/plugins/test.py
+++ b/mybot/plugins/test.py
@@ -1,5 +1,13 @@
 from pyrogram import Client, filters
+import logging
+
+from mybot.utils.decorators import log_errors
+
+LOGGER = logging.getLogger(__name__)
 
 @Client.on_message(filters.command("ping"))
+@log_errors
 async def ping_test(_, message):
+    LOGGER.info("ping command from %s", message.from_user.id)
     await message.reply_text("Pong! (test plugin)")
+

--- a/mybot/plugins/verify.py
+++ b/mybot/plugins/verify.py
@@ -1,10 +1,17 @@
 from pyrogram import Client, filters
 from pyrogram.enums import ParseMode, ChatMemberStatus
+import logging
+
 from mybot.button import CHANNEL_LINKS
+from mybot.utils.decorators import log_errors
+
+LOGGER = logging.getLogger(__name__)
 
 
 @Client.on_callback_query(filters.regex("^verify$"))
+@log_errors
 async def verify_cb(client, callback_query):
+    LOGGER.info("verify callback from %s", callback_query.from_user.id)
     """Verify if the user has joined all required channels."""
     user_id = callback_query.from_user.id
     missing = []
@@ -58,3 +65,4 @@ async def verify_cb(client, callback_query):
         )
 
     await callback_query.answer()
+

--- a/mybot/utils/decorators.py
+++ b/mybot/utils/decorators.py
@@ -1,0 +1,30 @@
+import functools
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def log_errors(func):
+    """Decorator to log exceptions and always reply with an error message."""
+
+    @functools.wraps(func)
+    async def wrapper(client, *args, **kwargs):
+        LOGGER.debug("Handler %s triggered", func.__name__)
+        try:
+            return await func(client, *args, **kwargs)
+        except Exception as exc:  # pragma: no cover - runtime safety
+            LOGGER.exception("Unhandled exception in %s", func.__name__)
+            # Try to reply politely using context information
+            for arg in args:
+                target = getattr(arg, "message", arg)
+                if hasattr(target, "reply_text"):
+                    try:
+                        await target.reply_text(
+                            "\u26a0\ufe0f An unexpected error occurred. Please try again later."
+                        )
+                    except Exception:
+                        pass
+                    break
+            return None
+
+    return wrapper


### PR DESCRIPTION
## Summary
- load all plugins in `main.py` and use `app.run()`
- add new `log_errors` decorator for global error handling
- apply decorator to all handlers and add safety logging
- wrap database operations in try/except blocks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688d160c476c8329b8ef8110502559a9