### PR TITLE
Fix Unicode logging issue

### DIFF
--- a/mybot/main.py
+++ b/mybot/main.py
@@ -54,10 +54,10 @@ def load_plugins() -> None:
 # Entrypoint
 # -------------------------------------------------------------
 async def start_bot() -> None:
-    LOGGER.info("\ud83d\udcdc Initializing database...")
+    LOGGER.info("\U0001F4DC Initializing database...")
     await init_db()
 
-    LOGGER.info("\ud83d\udd27 Loading plugins...")
+    LOGGER.info("\U0001F527 Loading plugins...")
     load_plugins()
 
 


### PR DESCRIPTION
## Summary
- avoid surrogate pair escapes in logging messages

## Testing
- `python -m compileall -q mybot`
- `python - <<'PY'
from mybot.main import LOGGER
LOGGER.info('\U0001F527 Test logging...')
PY
`

------
https://chatgpt.com/codex/tasks/task_b_688d187935308329afc2d8f6432e09de