### PR TITLE
Keep bot running and reduce MongoDB logging

### DIFF
--- a/mybot/config.py
+++ b/mybot/config.py
@@ -20,7 +20,7 @@ LOG_GROUP = os.getenv("LOG_GROUP")  # e.g., -1001234567890
 
 # Logging level. Defaults to INFO if not set.
 # Example values: DEBUG, INFO, WARNING, ERROR
-LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG").upper()
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 
 # Referral/withdrawal settings
 MIN_WITHDRAW = 15

--- a/mybot/main.py
+++ b/mybot/main.py
@@ -5,10 +5,11 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
-from pyrogram import Client
+from pyrogram import Client, idle
 
 from mybot import config
 from mybot.database import init_db
+from mybot.database.mongo import mongo_client
 
 # -------------------------------------------------------------
 # Logging setup
@@ -25,6 +26,7 @@ logging.basicConfig(
     ],
 )
 LOGGER = logging.getLogger(__name__)
+logging.getLogger("pymongo").setLevel(logging.WARNING)
 
 # -------------------------------------------------------------
 # Pyrogram Client
@@ -59,6 +61,11 @@ async def start_bot() -> None:
 
     LOGGER.info("\U0001F527 Loading plugins...")
     load_plugins()
+
+    LOGGER.info("Bot started. Listening for updates.")
+    await idle()
+    mongo_client.close()
+    LOGGER.info("Bot stopped.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- default log level to INFO to avoid noisy debug output
- keep bot alive with idle loop and close Mongo connection on exit
- suppress verbose pymongo debug messages

## Testing
- `python -m py_compile mybot/main.py mybot/config.py`


------
https://chatgpt.com/codex/tasks/task_b_688daf7a1cd883298e0b5c5726b5f2ba