### PR TITLE
Improve logging and plugin loading

### DIFF
--- a/mybot/plugins/admin.py
+++ b/mybot/plugins/admin.py
@@ -9,6 +9,7 @@ from mybot.button import SUPPORT_URL
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 
 # Admin Panel callback button

--- a/mybot/plugins/basic.py
+++ b/mybot/plugins/basic.py
@@ -7,6 +7,7 @@ from mybot import config
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 
 def start_text() -> str:

--- a/mybot/plugins/broadcast.py
+++ b/mybot/plugins/broadcast.py
@@ -8,6 +8,7 @@ from mybot import config
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 
 @Client.on_message(filters.command("broadcast") & filters.user(config.OWNER_ID))

--- a/mybot/plugins/referral.py
+++ b/mybot/plugins/referral.py
@@ -8,6 +8,7 @@ from mybot import config
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 
 # Callback: Show referral link and points

--- a/mybot/plugins/start.py
+++ b/mybot/plugins/start.py
@@ -8,6 +8,7 @@ from mybot.database.mongo import users_col, referrals_col
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 # Banner image shown on /start
 BANNER_URL = "https://via.placeholder.com/600x300.png?text=Refer+%26+Earn"

--- a/mybot/plugins/test.py
+++ b/mybot/plugins/test.py
@@ -4,6 +4,7 @@ import logging
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 @Client.on_message(filters.command("ping"))
 @log_errors

--- a/mybot/plugins/verify.py
+++ b/mybot/plugins/verify.py
@@ -6,6 +6,7 @@ from mybot.button import CHANNEL_LINKS
 from mybot.utils.decorators import log_errors
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.info("Plugin loaded: %s", __name__)
 
 
 @Client.on_callback_query(filters.regex("^verify$"))


### PR DESCRIPTION
## Summary
- ensure plugins load using an absolute path and add startup logs
- log all incoming updates and plugin imports for easier debugging
- handle database initialization errors gracefully so bot still runs

## Testing
- `python -m py_compile mybot/main.py mybot/plugins/admin.py mybot/plugins/basic.py mybot/plugins/broadcast.py mybot/plugins/referral.py mybot/plugins/start.py mybot/plugins/test.py mybot/plugins/verify.py`


------
https://chatgpt.com/codex/tasks/task_b_688dca8f3aa883299dd48c4e01b4e899