### PR TITLE
docs: clarify init db docstring

### DIFF
--- a/mybot/database/__init__.py
+++ b/mybot/database/__init__.py
@@ -8,7 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 async def init_db() -> None:
-    """Verify MongoDB connectivity and prepare collections."""
+    """Verify MongoDB connectivity."""
     try:
         await mongo_client.admin.command("ping")
     except Exception as exc:


### PR DESCRIPTION
## Summary
- clarify that `init_db` only checks MongoDB connectivity

## Testing
- `pytest -q`
- `python -m py_compile mybot/database/__init__.py`


------
https://chatgpt.com/codex/tasks/task_b_6890e64a09108330859de047515e97b1