### PR TITLE
Rename ping handler in test plugin

### DIFF
--- a/mybot/plugins/test.py
+++ b/mybot/plugins/test.py
@@ -6,9 +6,9 @@ from mybot.utils.decorators import log_errors
 LOGGER = logging.getLogger(__name__)
 LOGGER.info("Plugin loaded: %s", __name__)
 
-@Client.on_message(filters.command("ping"))
+@Client.on_message(filters.command("pingtest"))
 @log_errors
-async def ping_test(_, message):
-    LOGGER.info("ping command from %s", message.from_user.id)
+async def pingtest_cmd(_, message):
+    LOGGER.info("pingtest command from %s", message.from_user.id)
     await message.reply_text("Pong! (test plugin)")
 


### PR DESCRIPTION
## Summary
- rename `/ping` handler in test plugin to `/pingtest` to avoid overlap with basic plugin

## Testing
- `ruff check mybot/plugins/test.py mybot/plugins/basic.py`
- `ruff check mybot` (fails: F401, F841 in unrelated modules)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6890e64be2548330944bf8233bfb6333