### PR TITLE
Allow running bot via import

### DIFF
--- a/mybot/__init__.py
+++ b/mybot/__init__.py
@@ -1,1 +1,22 @@
+"""Helper entry point for running the Refer & Earn bot as a module."""
+
 from . import config
+
+
+def run() -> None:
+    """Start the bot application.
+
+    Importing :mod:`mybot` and calling :func:`run` provides a simple way to
+    execute the bot from another Python program, for example::
+
+        import mybot
+        mybot.run()
+
+    """
+
+    from .main import run as _run
+
+    _run()
+
+
+__all__ = ["run", "config"]

--- a/mybot/main.py
+++ b/mybot/main.py
@@ -82,7 +82,13 @@ async def on_startup() -> None:
     await idle()
 
 
-if __name__ == "__main__":
+def run() -> None:
+    """Convenience wrapper to start the bot.
+
+    This makes it possible to import ``mybot`` as a module and start the
+    application with ``mybot.run()`` instead of executing ``main.py``
+    directly.
+    """
     try:
         # ``app.run`` starts the client, runs the coroutine, handles ``idle``
         # internally, and stops the client on exit.
@@ -92,3 +98,7 @@ if __name__ == "__main__":
     finally:
         mongo_client.close()
         LOGGER.info("Bot stopped.")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add `mybot.run()` helper to start the bot when imported as a module
- expose entry point through package `__init__`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689df907a4948321aa57004ff88309cb