### PR TITLE
Load plugins to enable full /start panel

### DIFF
--- a/mybot/plugins/start.py
+++ b/mybot/plugins/start.py
@@ -10,8 +10,8 @@ from mybot.utils.decorators import log_errors
 LOGGER = logging.getLogger(__name__)
 LOGGER.info("Plugin loaded: %s", __name__)
 
-# Banner image shown on /start
-BANNER_URL = "https://via.placeholder.com/600x300.png?text=Refer+%26+Earn"
+# Banner image shown on /start. Environment variable can override.
+BANNER_URL = config.BANNER_URL or "https://via.placeholder.com/600x300.png?text=Refer+%26+Earn"
 
 WELCOME_TEXT = (
     "🎯 <b>Welcome to the Refer & Earn Bot</b>\n\n"


### PR DESCRIPTION
## Summary
- Replace placeholder `/start` handler with plugin-driven client so all command handlers load
- Warn when webhook mode is requested and fall back to long polling
- Allow start banner image to be overridden via `BANNER_URL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bc80ba641c8330a2fd0bc87dc13d05