### PR TITLE
fix: use module path for plugin root

### DIFF
--- a/mybot/main.py
+++ b/mybot/main.py
@@ -19,7 +19,7 @@ def create_client() -> Client:
         api_id=config.API_ID,
         api_hash=config.API_HASH,
         bot_token=config.BOT_TOKEN,
-        plugins=dict(root="mybot.plugins"),
+        plugins=dict(root=f"{__package__}.plugins"),
     )
 
 


### PR DESCRIPTION
## Summary
- derive Pyrogram plugin root from module package so imports always resolve

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bc845bd2d483309e0c2cbb67a527a5