### PR TITLE
Fix referral panel button callback

### DIFF
--- a/mybot/plugins/basic.py
+++ b/mybot/plugins/basic.py
@@ -6,6 +6,7 @@ import logging
 
 from mybot import config
 from mybot.utils.decorators import log_errors
+from mybot.ui.callbacks import build
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.info("Plugin loaded: %s", __name__)
@@ -21,7 +22,11 @@ def start_text() -> str:
 def start_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("🎯 Referral Panel", callback_data="referral")],
+            [
+                InlineKeyboardButton(
+                    "🎯 Referral Panel", callback_data=build({"route": "ref:open"})
+                )
+            ],
             [InlineKeyboardButton("📚 Help & Commands", callback_data="help_menu")],
             [InlineKeyboardButton("ℹ️ About", callback_data="about_menu")],
         ]

--- a/mybot/plugins/start.py
+++ b/mybot/plugins/start.py
@@ -6,6 +6,7 @@ from mybot import config
 from mybot import button
 from mybot.database.mongo import users_col, referrals_col
 from mybot.utils.decorators import log_errors
+from mybot.ui.callbacks import build
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.info("Plugin loaded: %s", __name__)
@@ -43,7 +44,9 @@ def get_start_keyboard(user_id: int) -> InlineKeyboardMarkup:
     buttons = list(join_buttons)
     buttons.append(
         [
-            InlineKeyboardButton("💎 Referral", callback_data="referral"),
+            InlineKeyboardButton(
+                "💎 Referral", callback_data=build({"route": "ref:open"})
+            ),
             InlineKeyboardButton("💰 Withdraw", callback_data="withdraw"),
         ]
     )

--- a/tests/test_referral_button.py
+++ b/tests/test_referral_button.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+from pathlib import Path
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mybot.ui import callbacks
+import mybot.plugins.start as start
+import mybot.plugins.basic as basic
+
+
+def _find_button(kb, text):
+    for row in kb.inline_keyboard:
+        for btn in row:
+            if btn.text == text:
+                return btn
+    raise AssertionError(f"Button with text {text} not found")
+
+
+def test_start_referral_button_callback():
+    kb = start.get_start_keyboard(123)
+    btn = _find_button(kb, "💎 Referral")
+    data = callbacks.parse(btn.callback_data)
+    assert data["route"] == "ref:open"
+
+
+def test_basic_referral_button_callback():
+    kb = basic.start_keyboard()
+    btn = _find_button(kb, "🎯 Referral Panel")
+    data = callbacks.parse(btn.callback_data)
+    assert data["route"] == "ref:open"


### PR DESCRIPTION
## Summary
- sign referral buttons with `callbacks.build` so the referral panel opens correctly
- add regression tests for start and basic keyboards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd18c9e7348330ba423ad4ad7ad511