### PR TITLE
Fix start command callback size causing ButtonDataInvalid

### DIFF
--- a/tests/test_referral_button.py
+++ b/tests/test_referral_button.py
@@ -23,6 +23,7 @@ def test_start_referral_button_callback():
     btn = _find_button(kb, "💎 Referral")
     data = callbacks.parse(btn.callback_data)
     assert data["route"] == "ref:open"
+    assert len(btn.callback_data) <= 64
 
 
 def test_basic_referral_button_callback():
@@ -30,3 +31,4 @@ def test_basic_referral_button_callback():
     btn = _find_button(kb, "🎯 Referral Panel")
     data = callbacks.parse(btn.callback_data)
     assert data["route"] == "ref:open"
+    assert len(btn.callback_data) <= 64


### PR DESCRIPTION
## Summary
- shorten callback data signatures to keep Telegram callback payloads under 64 bytes
- verify referral buttons generate compact, signed callback data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd1ff9b3948330ac7e525fa764de3d